### PR TITLE
Misleading attribute name

### DIFF
--- a/Builders/Html builders/src/Task.kt
+++ b/Builders/Html builders/src/Task.kt
@@ -31,4 +31,4 @@ fun renderProductTable(): String {
 }
 
 fun getTitleColor() = "#b9c9fe"
-fun getCellColor(index: Int, row: Int) = if ((index + row) % 2 == 0) "#dce4ff" else "#eff2ff"
+fun getCellColor(index: Int, column: Int) = if ((index + column) % 2 == 0) "#dce4ff" else "#eff2ff"


### PR DESCRIPTION
The parameter names of `getCellColor` function is not matching the invocations made to it in `renderProductTable`. I guess we either need to change the invocations to provide `index` as the second argument (since thats what contains the row number) like: `getCellColor(0, index)` or change the argument name to `column` (since that's what with the acutal invocations we pass in).