### PR TITLE
Clarify the partitionTo exercise

### DIFF
--- a/Generics/Generic functions/task.md
+++ b/Generics/Generic functions/task.md
@@ -6,7 +6,7 @@ a collection into two collections according to the predicate.
 
 There is a [`partition()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/kotlin.-iterable/partition.html)
 function in the standard library that always returns two newly created lists.
-You should write a function that splits the collection into two collections given as arguments.
+You should write a function with three parameters: the two collections and a predicate. The function should split the collection into two collections given as arguments using the given predicate and return a `Pair` containing the resulting collections.
 The signature of the
 [`toCollection()`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/kotlin.-iterable/to-collection.html)
  function from the standard library might help you.


### PR DESCRIPTION
The instructions for this exercise were very unclear and it seems a lot of information was missing. This commit clarifies the exercise by explaining the parameters and output of the `partitionTo` which needs to be implemented. 