### PR TITLE
[Collections/Associate] fix mixed up documentation links

### DIFF
--- a/Collections/Associate/task.md
+++ b/Collections/Associate/task.md
@@ -2,9 +2,9 @@
 
 Learn about [association](https://kotlinlang.org/docs/reference/collection-transformations.html#association).
 Implement the following functions using 
-[`associateBy`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/associate.html),
+[`associateBy`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/associate-by.html),
 [`associateWith`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/associate-with.html), 
-and [`associate`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/associate-by.html):
+and [`associate`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/associate.html):
 
 - Build a map from the customer name to the customer
 - Build a map from the customer to their city 


### PR DESCRIPTION
Fix links in the `task.md` for `Collections/Associate` where the link for `associateBy` leads to the documentation for `associate` and vice-versa.