### PR TITLE
[Collections] reorder to introduce flatMap before using in MaxMin

### DIFF
--- a/Collections/lesson-info.yaml
+++ b/Collections/lesson-info.yaml
@@ -2,13 +2,13 @@ content:
 - Introduction
 - Sort
 - Filter map
+- FlatMap
 - All Any and other predicates
 - Max min
 - Sum
 - Associate
 - GroupBy
 - Partition
-- FlatMap
 - Fold
 - Compound tasks
 - Sequences


### PR DESCRIPTION
The `Collections / Max Min` task uses `flatMap` in the solution:
https://github.com/Kotlin/kotlin-koans-edu/blob/bbb39c773c21eb1fe7cb91547f6b4ddb8114fb1a/Collections/Max%20min/src/Task.kt#L6-L9

There is a Koan explaining FlatMap which comes later in the chapter. This reorders `Collections` to introduce FlatMap before encountering the `Max Min` Koan.