### PR TITLE
Use count(), instead of size which forces to load the whole collection

### DIFF
--- a/Builders/The function apply/task.md
+++ b/Builders/The function apply/task.md
@@ -4,5 +4,25 @@ The previous examples can be rewritten using the library function
 [`apply`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/apply.html).
 Write your own implementation of this function named 'myApply'.
 
+```kotlin
+val adam = Person("Adam").apply {
+    age = 32
+    city = "London"        
+}
+println(adam)
+```
+
+```kotlin
+var currentStockValue = 0.0
+val inventory = HashMap<Product, Int>().apply {
+    put(Product("IntelliJ IDEA Ultimate", 199.0), 2)
+    put(Product("ReSharper", 149.0), 5)
+    put(Product("DotTrace", 129.0), 100)
+    put(Product("DotCover", 99.0), 0)
+    forEach { p, q -> currentStockValue += q * p.price }
+}
+print("Stock value is $currentStockValue\n")
+```
+
 Learn about the other [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html)
 and how to use them.

--- a/Builders/The function apply/task.md
+++ b/Builders/The function apply/task.md
@@ -4,25 +4,5 @@ The previous examples can be rewritten using the library function
 [`apply`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/apply.html).
 Write your own implementation of this function named 'myApply'.
 
-```kotlin
-val adam = Person("Adam").apply {
-    age = 32
-    city = "London"        
-}
-println(adam)
-```
-
-```kotlin
-var currentStockValue = 0.0
-val inventory = HashMap<Product, Int>().apply {
-    put(Product("IntelliJ IDEA Ultimate", 199.0), 2)
-    put(Product("ReSharper", 149.0), 5)
-    put(Product("DotTrace", 129.0), 100)
-    put(Product("DotCover", 99.0), 0)
-    forEach { p, q -> currentStockValue += q * p.price }
-}
-print("Stock value is $currentStockValue\n")
-```
-
 Learn about the other [scope functions](https://kotlinlang.org/docs/reference/scope-functions.html)
 and how to use them.

--- a/Collections/Max min/src/Task.kt
+++ b/Collections/Max min/src/Task.kt
@@ -1,6 +1,6 @@
 // Return a customer who has placed the maximum amount of orders
 fun Shop.getCustomerWithMaxOrders(): Customer? =
-        customers.maxBy { it.orders.size }
+        customers.maxBy { it.orders.count() }
 
 // Return the most expensive product that has been ordered by the given customer
 fun getMostExpensiveProductBy(customer: Customer): Product? =


### PR DESCRIPTION
We may as well show good practice, and void using the implementation of count() in this particular case.
In general, count() is recommended since it may avoid loading the whole collection in memory, if implemented accordingly.