### PR TITLE
Add `operator` keyword to invoke example

### DIFF
--- a/Conventions/Invoke/task.md
+++ b/Conventions/Invoke/task.md
@@ -6,7 +6,7 @@ method can be invoked as a function.
 You can add an `invoke` extension for any class, but it's better not to overuse it:
 
 ```kotlin
-fun Int.invoke() { println(this) }
+operator fun Int.invoke() { println(this) }
 
 1() //huh?..
 ```


### PR DESCRIPTION
Seems like example for `invoke` is missing the `operator` keyword for it to be valid.

```kotlin
operator fun Int.invoke() { println(this) }
```
