### PR TITLE
Moved flatMap section

### DIFF
--- a/Collections/lesson-info.yaml
+++ b/Collections/lesson-info.yaml
@@ -2,13 +2,13 @@ content:
 - Introduction
 - Sort
 - Filter map
+- FlatMap
 - All Any and other predicates
 - Max min
 - Sum
 - Associate
 - GroupBy
 - Partition
-- FlatMap
 - Fold
 - Compound tasks
 - Sequences


### PR DESCRIPTION
Previous koans used the flatMap function in their solutions before the flatMap koan.
To avoid confusion for possible newcomers, the flatMap section has been moved up.