### PR TITLE
build(build.gradle): compile/testCompile configurations updated to im…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ subprojects {
     }
 
     dependencies {
-        compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-        testCompile group: 'junit', name: 'junit', version: '4.12'
+        implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+        testImplementation group: 'junit', name: 'junit', version: '4.12'
     }
 
     compileKotlin.destinationDir = compileJava.destinationDir
@@ -65,13 +65,13 @@ subprojects {
 
 project(':util') {
     dependencies {
-        compile group: 'junit', name: 'junit', version: '4.12'
+        implementation group: 'junit', name: 'junit', version: '4.12'
     }
 }
 
 configure(subprojects.findAll {it.name != 'util'}) {
   dependencies {
-    compile project(':util').sourceSets.main.output
-    testCompile project(':util').sourceSets.test.output
+    implementation project(':util').sourceSets.main.output
+    testImplementation project(':util').sourceSets.test.output
   }
 }


### PR DESCRIPTION
…plementation/testImplementation

Previously, we used compile and testCompile configurations in
build.gradle to add dependencies.
But in Gradle 7.0 these configurations
were removed that may lead to error during course project loading

Closes https://youtrack.jetbrains.com/issue/EDC-486