### PR TITLE
Remove not-null assertion operator from Lazy property task

### DIFF
--- a/Properties/Lazy property/src/Task.kt
+++ b/Properties/Lazy property/src/Task.kt
@@ -2,9 +2,6 @@ class LazyProperty(val initializer: () -> Int) {
     var value: Int? = null
     val lazy: Int
         get() {
-            if (value == null) {
-                value = initializer()
-            }
-            return value!!
+            return value ?: initializer().also { value = it }
         }
 }

--- a/Properties/Lazy property/task-info.yaml
+++ b/Properties/Lazy property/task-info.yaml
@@ -7,7 +7,7 @@ files:
     length: 22
     placeholder_text: /* TODO */
   - offset: 122
-    length: 99
+    length: 49
     placeholder_text: TODO()
 - name: test/tests.kt
   visible: false


### PR DESCRIPTION
A shorter way to solve this task that avoids using the `!!` opeator