### PR TITLE
Fix Triple-quoted strings docs link

### DIFF
--- a/Introduction/Triple-quoted strings/task.md
+++ b/Introduction/Triple-quoted strings/task.md
@@ -1,6 +1,6 @@
 ## Triple-quoted strings
 
-Learn about the [different string literals and string templates](https://kotlinlang.org/docs/basic-types.html#string-literals)
+Learn about the [different string literals and string templates](https://kotlinlang.org/docs/strings.html#string-literals)
 in Kotlin.
 
 You can use the handy library functions 


### PR DESCRIPTION
The current link doesn't actually lead to the relevant docs, this PR updates the link to the correct page. 